### PR TITLE
Add unit test for blocked user in autoreview

### DIFF
--- a/app/reviews/autoreview.py
+++ b/app/reviews/autoreview.py
@@ -97,6 +97,24 @@ def _evaluate_revision(
         }
     )
 
+    if profile and getattr(profile, "is_blocked", False):
+        tests.append(
+            {
+                "id": "blocked-user",
+                "title": "Blocked user",
+                "status": "fail",
+                "message": "The user is currently blocked and cannot be auto-approved.",
+            }
+        )
+        return {
+            "tests": tests,
+            "decision": AutoreviewDecision(
+                status="blocked",
+                label="Cannot be auto-approved",
+                reason="The user is currently blocked.",
+            ),
+        }
+
     # Test 2: Editors in the allow-list can be auto-approved.
     if auto_groups:
         matched_groups = _matched_user_groups(

--- a/app/reviews/tests/test_autoreview.py
+++ b/app/reviews/tests/test_autoreview.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+from reviews import autoreview
+
+class AutoreviewBlockedUserTests(TestCase):
+    def test_blocked_user_not_auto_approved(self):
+        blocked_profile = MagicMock()
+        blocked_profile.is_blocked = True
+        blocked_profile.is_bot = False
+        blocked_profile.is_autopatrolled = False
+        blocked_profile.is_autoreviewed = False
+        blocked_profile.usergroups = []
+
+        revision = MagicMock()
+        revision.user_name = "BlockedUser"
+        revision.superset_data = {}
+        revision.page.categories = []
+
+        result = autoreview._evaluate_revision(
+            revision,
+            blocked_profile,
+            auto_groups={},
+            blocking_categories={},
+        )
+
+        self.assertEqual(result["decision"].status, "blocked")
+        self.assertTrue(any(t["id"] == "blocked-user" for t in result["tests"]))


### PR DESCRIPTION
Fixes : #8 

Problem

Edits made before a user was blocked could be auto-approved if the block occurred between the edit and bot review.
Changes

Added blocked user check in _evaluate_revision() in autoreview.py
Edits from blocked users now fail auto-approval with status "blocked"
Added test test_blocked_user_not_auto_approved() in test_autoreview.py