### PR TITLE
Add FlaggedRevs info links to UI (T406294)

### DIFF
--- a/app/static/reviews/app.js
+++ b/app/static/reviews/app.js
@@ -375,6 +375,14 @@ createApp({
       return `/wiki/Special:Contributions/${encoded}`;
     }
 
+    function buildFlaggedRevsUrl(specialPage) {
+      const origin = getWikiOrigin();
+      if (!origin) {
+        return "";
+      }
+      return `${origin}/wiki/Special:${specialPage}?uselang=en`;
+    }
+
     function toggleConfiguration() {
       state.configurationOpen = !state.configurationOpen;
     }
@@ -540,6 +548,7 @@ createApp({
       buildLatestRevisionUrl,
       buildRevisionDiffUrl,
       buildUserContributionsUrl,
+      buildFlaggedRevsUrl,
       runAutoreview,
       runAutoreviewAllVisible,
       getRevisionReview,

--- a/app/templates/reviews/index.html
+++ b/app/templates/reviews/index.html
@@ -35,6 +35,20 @@
                   <button class="button is-warning" @click="clearCache">Clear cache</button>
                 </div>
               </div>
+              <div class="field mt-3" v-if="currentWiki">
+                <label class="label is-small">FlaggedRevs Quick Links:</label>
+                <div class="buttons">
+                  <a :href="buildFlaggedRevsUrl('ValidationStatistics')" class="button is-small is-link is-light" target="_blank" rel="noopener noreferrer">
+                    Validation Statistics
+                  </a>
+                  <a :href="buildFlaggedRevsUrl('PendingChanges')" class="button is-small is-link is-light" target="_blank" rel="noopener noreferrer">
+                    Pending Changes
+                  </a>
+                  <a :href="buildFlaggedRevsUrl('Log/Review')" class="button is-small is-link is-light" target="_blank" rel="noopener noreferrer">
+                    Review Log
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Added FlaggedRevs quick access links below the wiki selection dropdown. Users can now quickly navigate to ValidationStatistics, PendingChanges, and Review Log pages with one click.

Linked Issues:
https://phabricator.wikimedia.org/T406294

Changes Included:
- Added buildFlaggedRevsUrl() function in app.js to generate dynamic Wikipedia Special page URLs
- Added UI section in index.html with three quick link buttons
- Links automatically update based on selected wiki
- All links include `?uselang=en` parameter for English interface

<img width="869" height="285" alt="image" src="https://github.com/user-attachments/assets/2451c8df-5ad1-4d2f-ade9-0a31ee3e7551" />



