### PR TITLE
Suppress confusing error message in unit tests (#35)

### DIFF
--- a/app/reviews/tests/test_views.py
+++ b/app/reviews/tests/test_views.py
@@ -41,8 +41,9 @@ class ViewTests(TestCase):
         ]
         self.assertCountEqual(codes, expected_codes)
 
+    @mock.patch("reviews.views.logger")
     @mock.patch("reviews.views.WikiClient")
-    def test_api_refresh_returns_error_on_failure(self, mock_client):
+    def test_api_refresh_returns_error_on_failure(self, mock_client, mock_logger):
         mock_client.return_value.refresh.side_effect = RuntimeError("failure")
         response = self.client.post(reverse("api_refresh", args=[self.wiki.pk]))
         self.assertEqual(response.status_code, 502)


### PR DESCRIPTION
Fixes #35

Suppress the confusing `"Failed to refresh pending changes for test"` error message that appears during test runs even though tests pass successfully.
Changes
- Mock the logger in `test_api_refresh_returns_error_on_failure` to prevent error traceback from being printed to console
- Test still validates error handling behavior correctly, but without the noisy output

Testing
- All tests pass
- No linting errors
- Error message no longer appears in test output