### PR TITLE
fix confusing logs

### DIFF
--- a/app/reviews/tests/test_views.py
+++ b/app/reviews/tests/test_views.py
@@ -25,7 +25,7 @@ class ViewTests(TestCase):
             family="wikipedia",
             api_endpoint="https://test.wikipedia.org/w/api.php",
         )
-        WikiConfiguration.objects.create(wiki=self.wiki)
+        WikiConfiguration.objects.create(wiki=self.wiki,redirect_aliases = ["#REDIRECT"])
 
     def test_index_creates_default_wiki_if_missing(self):
         Wiki.objects.all().delete()
@@ -398,14 +398,13 @@ class ViewTests(TestCase):
         revision.refresh_from_db()
         self.assertEqual(revision.wikitext, "Hidden [[Category:Secret]]")
         self.assertEqual(revision.categories, ["Secret"])
-        # 2 requests: 1 for redirect aliases, 1 for wikitext
-        self.assertEqual(len(fake_site.requests), 2)
+        # 1 request for wikitext (redirect aliases already cached in setUp)
+        self.assertEqual(len(fake_site.requests), 1)
 
         second_response = self.client.post(url)
         self.assertEqual(second_response.status_code, 200)
-        # redirect aliases are now cached, wikitext was already cached
-        # No new API calls are made on the second request
-        self.assertEqual(len(fake_site.requests), 2)
+        # wikitext was already cached, no new API calls are made
+        self.assertEqual(len(fake_site.requests), 1)
 
     @mock.patch("reviews.models.pywikibot.Site")
     @mock.patch("reviews.services.pywikibot.Site")


### PR DESCRIPTION
Fixes : #51 


Since this test is not testing for the API which is call to fetch magic words, we can simply create config with cache data to avoid fallbacks 


Before - 

<img width="818" height="402" alt="image" src="https://github.com/user-attachments/assets/e2a78757-651c-417b-b0b9-e0f570ae92c1" />


After - 
<img width="805" height="281" alt="image" src="https://github.com/user-attachments/assets/9ae66055-f2bf-4e05-94e6-7ccf320b6edb" />
