### PR TITLE
Adding LiftWing model visualization feature

### DIFF
--- a/app/reviews/models.py
+++ b/app/reviews/models.py
@@ -185,3 +185,4 @@ class EditorProfile(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - debug helper
         return f"{self.username} on {self.wiki.code}"
+

--- a/app/reviews/urls.py
+++ b/app/reviews/urls.py
@@ -7,6 +7,8 @@ urlpatterns = [
     path("api/wikis/", views.api_wikis, name="api_wikis"),
     path("api/wikis/<int:pk>/refresh/", views.api_refresh, name="api_refresh"),
     path("api/wikis/<int:pk>/pending/", views.api_pending, name="api_pending"),
+    path("liftwing/", views.liftwing_page, name="liftwing"),
+    path("api/visualization/validate/", views.validate_article, name="validate_article"),
     path(
         "api/wikis/<int:pk>/pages/<int:pageid>/revisions/",
         views.api_page_revisions,

--- a/app/reviews/views.py
+++ b/app/reviews/views.py
@@ -420,3 +420,39 @@ def fetch_diff(request):
         return HttpResponse(html_content, content_type="text/html")
     except requests.RequestException as e:
         return JsonResponse({"error": str(e)}, status=500)
+
+
+
+def liftwing_page(request):
+    return render(request, "reviews/lift.html")
+
+def validate_article(request):
+    if request.method == "POST":
+        import json
+        data = json.loads(request.body)
+        wiki = data.get("wiki")
+        article = data.get("article")
+        # TODO: Implement actual validation (API call to MediaWiki)
+        if article and len(article.strip()) > 2:
+            return JsonResponse({"valid": True})
+        else:
+            return JsonResponse({"valid": False})
+    return JsonResponse({"error": "Invalid method"}, status=405)
+
+@require_GET
+def liftwing_models(request, wiki_code):
+    """Return available LiftWing models for the given wiki."""
+    # For now, return a static list of available models
+    models = [
+        {
+            "name": "articlequality",
+            "version": "1.0.0",
+            "description": "Predicts the quality class of Wikipedia articles"
+        },
+        {
+            "name": "draftquality",
+            "version": "1.0.0", 
+            "description": "Predicts the quality of new article drafts"
+        }
+    ]
+    return JsonResponse({"models": models})

--- a/app/templates/reviews/lift.html
+++ b/app/templates/reviews/lift.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>LiftWing Model Visualization</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2rem;
+        }
+
+        .form-section {
+            margin-bottom: 1.5rem;
+        }
+
+        input,
+        select,
+        button {
+            padding: 0.5rem;
+            font-size: 1rem;
+        }
+    </style>
+    <script>
+        async function validateArticle() {
+            const wiki = document.getElementById("wiki").value;
+            const article = document.getElementById("article").value;
+
+            const resp = await fetch("/api/visualization/validate/", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": getCookie('csrftoken')
+                },
+                body: JSON.stringify({ wiki, article })
+            });
+
+            const data = await resp.json();
+            const result = document.getElementById("result");
+            if (data.valid) {
+                result.innerText = "✅ Article found!";
+                result.style.color = "green";
+            } else {
+                result.innerText = "❌ Article not found";
+                result.style.color = "red";
+            }
+        }
+
+        function getCookie(name) {
+            let cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                const cookies = document.cookie.split(';');
+                for (let i = 0; i < cookies.length; i++) {
+                    const cookie = cookies[i].trim();
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+    </script>
+</head>
+
+<body>
+    <h1>LiftWing Model Visualization</h1>
+
+    <div class="form-section">
+        <label for="wiki">Select Wiki:</label>
+        <select id="wiki">
+            <option value="en">English</option>
+            <option value="fi">Finnish</option>
+            <option value="fr">French</option>
+        </select>
+    </div>
+
+    <div class="form-section">
+        <label for="article">Article Title:</label>
+        <input type="text" id="article" placeholder="e.g., Albert Einstein">
+        <button onclick="validateArticle()">Validate</button>
+        <div id="result" style="margin-top: 0.5rem;"></div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
This PR introduces the initial structure for the LiftWing model visualization feature, as described in [Issue #70](https://github.com/Wikimedia-Suomi/PendingChangesBot-ng/issues/70)

It adds a new web page and basic API endpoints to support wiki and article selection, as the first step toward full visualization of LiftWing model scores across Wikipedia article revision histories.

**What's Implemented**

- New route & template for LiftWing visualization page (/liftwing/)
- Basic HTML UI for selecting wiki and validating article existence
- New validate_article API endpoint (currently stubbed with simple string length check)
- Static model list endpoint (liftwing_models) returning example model data
- Added URL patterns in urls.py for new endpoints
- Added liftwing_page view and lift.html template with basic styling and client-side validation logic


**To-Do**

- This PR is incomplete. The following major items still need to be implemented before closing #70:
-  Article validation via real MediaWiki API instead of placeholder check
-  Revision history fetching for selected article, including pagination
-  Database integration to cache revision data and model predictions
-  Model selection UI (currently hardcoded static model list)
-  LiftWing API integration for fetching model predictions per revision
-  Caching logic to avoid duplicate API calls
-  Line chart visualization (Chart.js or similar) showing model scores over revisions
-  Revision list table synced with graph (timestamps, usernames, comments, clickable diffs)
-  Error handling, loading indicators, and async fetching for large revision sets