### PR TITLE
Fix test data format to match new query structure

### DIFF
--- a/app/reviews/tests/test_flaggedrevs_statistics.py
+++ b/app/reviews/tests/test_flaggedrevs_statistics.py
@@ -296,11 +296,11 @@ class LoadStatisticsCommandTests(TestCase):
         mock_superset = MagicMock()
         mock_superset.query.return_value = [
             {
-                "d": "202401",
-                "totalPages_ns0": 1000,
-                "syncedPages_ns0": 800,
-                "reviewedPages_ns0": 900,
-                "pendingLag_average": 2.5,
+                "yearmonth": "202401",
+                "totalPages_ns0_avg": 1000,
+                "syncedPages_ns0_avg": 800,
+                "reviewedPages_ns0_avg": 900,
+                "pendingLag_average_avg": 2.5,
             }
         ]
         mock_superset_query.return_value = mock_superset


### PR DESCRIPTION
Fixes the test data format in `test_flaggedrevs_statistics.py` to match the renamed command and its updated SQL query that uses` yearmonth` instead of `d`.

Changes
- Update mock response fields from `d `→ `yearmonth`
- Update mock response fields from `_ns0 `→ `_ns0_avg`
- Ensure tests call load_flaggedrevs_statistics instead of the old load_statistics command

Testing
All 20 tests pass. 