### PR TITLE
Fix mypy type errors in tests and views

### DIFF
--- a/app/review_statistics/views.py
+++ b/app/review_statistics/views.py
@@ -263,9 +263,9 @@ def api_statistics_charts(request: HttpRequest, pk: int) -> JsonResponse:
     ).order_by("reviewed_timestamp")
 
     # Group data by date or hour depending on time filter
-    reviewers_by_date = defaultdict(set)
-    pending_by_date = defaultdict(int)
-    delays_by_date = defaultdict(list)
+    reviewers_by_date: dict[str, set[str]] = defaultdict(set)
+    pending_by_date: dict[str, int] = defaultdict(int)
+    delays_by_date: dict[str, list[float]] = defaultdict(list)
 
     # For "day" filter, group by hour; otherwise by date
     use_hourly = time_filter == "day"
@@ -487,7 +487,7 @@ def api_flaggedrevs_months(request: HttpRequest) -> JsonResponse:
         FlaggedRevsStatistics.objects.values_list("date", flat=True).distinct().order_by("-date")
     )
 
-    months = []
+    months: list[dict[str, str]] = []
     for date in months_data:
         month_value = date.strftime("%Y%m")
 

--- a/app/reviews/management/commands/run_wiki_diff_tests.py
+++ b/app/reviews/management/commands/run_wiki_diff_tests.py
@@ -5,7 +5,7 @@ import io
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import timedelta, timezone as dt_timezone
 from urllib.parse import parse_qs, urlparse
 
 import pywikibot
@@ -190,7 +190,7 @@ class Command(BaseCommand):
     def _fetch_wikitext(self, site: pywikibot.Site, title: str) -> str:
         page = pywikibot.Page(site, title)
         try:
-            return page.get()
+            return str(page.get())
         except Exception:  # pragma: no cover - network failures handled at runtime
             self.stderr.write(self.style.ERROR(f"Failed to fetch page '{title}'."))
             return ""
@@ -379,7 +379,7 @@ class Command(BaseCommand):
         if timestamp is None:
             return None
         if timezone.is_naive(timestamp):
-            timestamp = timezone.make_aware(timestamp, timezone=timezone.utc)
+            timestamp = timezone.make_aware(timestamp, timezone=dt_timezone.utc)
         return timestamp
 
     def _ensure_editor_profile(

--- a/app/reviews/tests/test_services.py
+++ b/app/reviews/tests/test_services.py
@@ -18,7 +18,7 @@ class FakeRequest:
 
 class FakeSite:
     def __init__(self):
-        self.response = {"query": {"pages": []}}
+        self.response: dict[str, dict[str, list]] = {"query": {"pages": []}}
         self.users_data: dict[str, dict] = {}
         self.requests: list[dict] = []
 

--- a/app/reviews/tests/test_services_parsers.py
+++ b/app/reviews/tests/test_services_parsers.py
@@ -24,21 +24,25 @@ class ParsersTests(TestCase):
     def test_parse_superset_timestamp_iso_format(self):
         result = parse_superset_timestamp("2024-01-01T12:00:00+00:00")
         self.assertIsNotNone(result)
+        assert result is not None  # for mypy
         self.assertEqual(result.year, 2024)
 
     def test_parse_superset_timestamp_with_z(self):
         result = parse_superset_timestamp("2024-01-01T12:00:00Z")
         self.assertIsNotNone(result)
+        assert result is not None  # for mypy
         self.assertEqual(result.tzinfo, timezone.utc)
 
     def test_parse_superset_timestamp_with_space(self):
         result = parse_superset_timestamp("2024-01-01 12:00:00")
         self.assertIsNotNone(result)
+        assert result is not None  # for mypy
         self.assertEqual(result.year, 2024)
 
     def test_parse_superset_timestamp_14_digit_format(self):
         result = parse_superset_timestamp("20240101120000")
         self.assertIsNotNone(result)
+        assert result is not None  # for mypy
         self.assertEqual(result.year, 2024)
         self.assertEqual(result.month, 1)
         self.assertEqual(result.day, 1)

--- a/app/reviews/tests/test_views.py
+++ b/app/reviews/tests/test_views.py
@@ -748,6 +748,7 @@ class ViewTests(TestCase):
 
         cutoff = get_time_filter_cutoff("week")
         self.assertIsNotNone(cutoff)
+        assert cutoff is not None  # for mypy
         self.assertLess((datetime.now(timezone.utc) - cutoff).days, 8)
 
     def test_statistics_page_no_wikis(self):


### PR DESCRIPTION
- Add explicit type annotations for defaultdict usage in views
- Add mypy type narrowing assertions in test files
- Fix timezone.utc reference conflict in run_wiki_diff_tests.py
- Explicitly cast pywikibot Page.get() return value to str

This commit fixes 13 mypy type checking errors:
- 3 var-annotated errors (pending_by_date, months, response)
- 8 union-attr errors in tests (Optional datetime/model access)
- 2 errors in run_wiki_diff_tests command

Part of ongoing effort to enable mypy type checking in CI (continuation of PR #138).

Related: #138