### PR TITLE
Fix mypy Optional/None errors in autoreview tests

### DIFF
--- a/app/reviews/tests/autoreview/test_article_to_redirect.py
+++ b/app/reviews/tests/autoreview/test_article_to_redirect.py
@@ -105,6 +105,8 @@ class ArticleToRedirectTests(TestCase):
 
         result = check_article_to_redirect(context)
         self.assertEqual(result.status, "fail")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "blocked")
         self.assertTrue(result.should_stop)
         self.assertIn("autoreview rights", result.message)

--- a/app/reviews/tests/autoreview/test_auto_approved_groups.py
+++ b/app/reviews/tests/autoreview/test_auto_approved_groups.py
@@ -28,6 +28,8 @@ class AutoApprovedGroupsTests(TestCase):
 
         result = check_auto_approved_groups(context)
         self.assertEqual(result.status, "ok")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "approve")
         self.assertTrue(result.should_stop)
         self.assertIn("sysop", result.message)
@@ -75,6 +77,8 @@ class AutoApprovedGroupsTests(TestCase):
 
         result = check_auto_approved_groups(context)
         self.assertEqual(result.status, "ok")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "approve")
         self.assertTrue(result.should_stop)
         self.assertIn("Autoreviewed", result.message)

--- a/app/reviews/tests/autoreview/test_invalid_isbn_check.py
+++ b/app/reviews/tests/autoreview/test_invalid_isbn_check.py
@@ -54,6 +54,8 @@ class InvalidISBNCheckTests(TestCase):
 
         result = check_invalid_isbn(context)
         self.assertEqual(result.status, "fail")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "blocked")
         self.assertTrue(result.should_stop)
         self.assertIn("invalid ISBN", result.message)

--- a/app/reviews/tests/autoreview/test_ores_scores.py
+++ b/app/reviews/tests/autoreview/test_ores_scores.py
@@ -91,6 +91,8 @@ class OresScoreTests(TestCase):
         result = check_ores_scores(context)
 
         self.assertEqual(result.status, "fail")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "blocked")
         self.assertIn("0.850", result.message)
 
@@ -138,6 +140,8 @@ class OresScoreTests(TestCase):
         result = check_ores_scores(context)
 
         self.assertEqual(result.status, "fail")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "blocked")
         self.assertIn("0.250", result.message)
 
@@ -314,5 +318,7 @@ class OresScoreTests(TestCase):
         result = check_ores_scores(context)
 
         self.assertEqual(result.status, "fail")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "blocked")
         self.assertIn("Could not verify", result.message)

--- a/app/reviews/tests/autoreview/test_superseded_additions.py
+++ b/app/reviews/tests/autoreview/test_superseded_additions.py
@@ -169,6 +169,8 @@ class SupersededAdditionsTests(TestCase):
 
         result = check_superseded_additions(context)
         self.assertEqual(result.status, "ok")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "approve")
         self.assertTrue(result.should_stop)
 

--- a/app/reviews/tests/autoreview/test_user_block.py
+++ b/app/reviews/tests/autoreview/test_user_block.py
@@ -68,6 +68,8 @@ class AutoreviewBlockedUserTests(TestCase):
 
         # Assert
         self.assertEqual(result.status, "fail")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "blocked")
         self.assertIn("blocked", result.message.lower())
 
@@ -106,5 +108,7 @@ class AutoreviewBlockedUserTests(TestCase):
 
         # Should handle exception and return fail status
         self.assertEqual(result.status, "fail")
+        self.assertIsNotNone(result.decision)
+        assert result.decision is not None  # for mypy
         self.assertEqual(result.decision.status, "error")
         self.assertIn("Could not verify", result.message)


### PR DESCRIPTION
Add mypy type narrowing assertions for result.decision checks across all autoreview test files. This pattern adds 'assert result.decision is not None' after assertIsNotNone() to help mypy track the non-None state.

Fixes 9 union-attr mypy errors in:
- test_user_block.py (2 errors)
- test_ores_scores.py (3 errors)
- test_invalid_isbn_check.py (1 error)
- test_auto_approved_groups.py (2 errors)
- test_article_to_redirect.py (1 error)
- test_superseded_additions.py (1 error - decision status only)

Part of ongoing effort to enable mypy in CI (continuation of PR #138, #XXX).

Related: #138